### PR TITLE
Feature/start screen with instructions

### DIFF
--- a/css/demo.css
+++ b/css/demo.css
@@ -99,16 +99,14 @@ a:focus {
 	flex-direction: row;
 	flex-wrap: wrap;
 	align-items: center;
+	justify-content: space-around;
 	width: 100%;
 	padding: 2em;
-	/*Changes for Win,Lose, Restart Messages*/
-	flex-direction: column;
-	justify-content: flex-end;
-	height: 50%;
+	/* height: 50%; */
 }
 
 .codrops-header__title {
-	font-size: 1.85em;
+	font-size: 2em;
 	font-weight: normal;
 	margin: 0;
 	padding: 0;
@@ -123,17 +121,40 @@ a:focus {
 .codrops-header__info {
 	margin: 1em;
 	font-weight: bold;
+	/* width: 50%; */
 }
 
 .in-game-header {
-	position: absolute;
-	display: flex;
+	/* position: absolute; */
+	/* display: flex;
 	flex-direction: row-reverse;
 	flex-wrap: wrap;
 	align-items: center;
 	width: 100%;
 	padding: 2em;
-	justify-content: flex-start;
+	justify-content: flex-start; */
+}
+
+
+section.start-to-finish {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
+	letter-spacing: 1px;
+	margin-top: 10%;
+
+}
+section.instructions {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	letter-spacing: 1px;
+	margin-top: 10%;
+
+}
+section.instructions p{
+	font-size: 16px;
 }
 
 /* Top Navigation Style

--- a/index.html
+++ b/index.html
@@ -24,6 +24,20 @@
 			</symbol>
 		</svg> -->
 		<main>
+			<header class="codrops-header start-screen">
+				<h1 class="codrops-header__title">Welcome to Tunnelscape!</h1>
+				<button class="codrops-header__info" onclick="startGame()" title="Start" >
+					START
+				</button>
+				<section class="instructions">
+					<p>INSTRUCTIONS</p>
+					<p>&#149; Arrow keys to move UP, DOWN, LEFT & RIGHT</p>
+					<p>&#149; 'W' to move forward through the tunnel</p>
+					<p>&#149; Move out of the way of the rocks & collect the diamonds</p>
+					<p>&#149; Reach the finish line before you run out of health</p>
+				</section>
+			</header>
+
 			<header class="codrops-header win">
 				<h1 class="codrops-header__title">YOU WON!</h1>
 				<button class="codrops-header__info" onclick="restartGame()" title="Play Again" >

--- a/index.html
+++ b/index.html
@@ -24,13 +24,24 @@
 			</symbol>
 		</svg> -->
 		<main>
+			<header class="codrops-header in-game-header">
+				<nav class="demos">
+					<p class="demo" id="score">SCORE: 0</p>
+					<div class="health-bar">
+						<progress max="100" value="70"></progress>
+					</div>
+				</nav>
+			</header>
 			<header class="codrops-header start-screen">
-				<h1 class="codrops-header__title">Welcome to Tunnelscape!</h1>
-				<button class="codrops-header__info" onclick="startGame()" title="Start" >
-					START
-				</button>
+				<section class="start-to-finish">
+					<h1 class="codrops-header__title">Welcome to Tunnelscape!</h1>
+					<button class="codrops-header__info" onclick="startGame()" title="Start" >
+						START
+					</button>
+				</section>
+				
 				<section class="instructions">
-					<p>INSTRUCTIONS</p>
+					<h3>INSTRUCTIONS</h3>
 					<p>&#149; Arrow keys to move UP, DOWN, LEFT & RIGHT</p>
 					<p>&#149; 'W' to move forward through the tunnel</p>
 					<p>&#149; Move out of the way of the rocks & collect the diamonds</p>
@@ -39,24 +50,21 @@
 			</header>
 
 			<header class="codrops-header win">
-				<h1 class="codrops-header__title">YOU WON!</h1>
-				<button class="codrops-header__info" onclick="restartGame()" title="Play Again" >
-					PLAY AGAIN?
-				</button>
+				<section class="start-to-finish">
+					<h1 class="codrops-header__title">YOU WON!</h1>
+					<button class="codrops-header__info" onclick="restartGame()" title="Play Again" >
+						PLAY AGAIN?
+					</button>
+				</section>
 			</header>
+
 			<header class="codrops-header lose">
-				<h1 class="codrops-header__title">YOU LOST!</h1>
-				<button class="codrops-header__info" onclick="restartGame()" title="Try Again">
-					TRY AGAIN?
-				</button>
-			</header>
-			<header class="in-game-header">
-				<nav class="demos">
-					<p class="demo" id="score">SCORE: 0</p>
-					<div class="health-bar">
-						<progress max="100" value="70"></progress>
-					</div>
-				</nav>
+				<section class="start-to-finish">
+					<h1 class="codrops-header__title">YOU LOST!</h1>
+					<button class="codrops-header__info" onclick="restartGame()" title="Try Again">
+						TRY AGAIN?
+					</button>
+				</section>
 			</header>
 			
 			<div class="content">

--- a/js/goldenProject.js
+++ b/js/goldenProject.js
@@ -361,8 +361,7 @@ Tunnel.prototype.render = function() {
     // Update camera position & rotation
     this.updateCameraPosition();
 
-    // Update the tunnel 
-    // - Check what this does?
+    // Update the tunnel - needs further checking as to what this does exactly
     this.updateCurve();
 
     /**Round pos values to first 2 decimal places */
@@ -686,7 +685,6 @@ function checkTextures() {
 function startGame() {
   gameState = "play";
   startScreenElt.style.display = "none";
-  console.log("startGame() was clicked and reached")
 }
 
 /**Restart game */


### PR DESCRIPTION
### Start screen with instructions

- The feature includes a still game screen with a "START" button on the left.
- It also includes instructions on how to play the game placed towards the right.
- The gameState, "start" is used for this stage of the game.
- In "start" gameState, the NPC particles are not created and the PC is prevented from moving forward.
- Clicking the START button, changes the gameState to "play", thus starting the game.

